### PR TITLE
Added ability to specify the mode of the Macvtap interface when this is selected.

### DIFF
--- a/ui/netlist.ui
+++ b/ui/netlist.ui
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.40.0 -->
+<!-- Generated with glade 3.38.2 -->
 <interface>
   <requires lib="gtk+" version="3.22"/>
   <!-- n-columns=2 n-rows=6 -->
@@ -60,14 +60,10 @@
             <property name="visible">True</property>
             <property name="can-focus">False</property>
             <property name="halign">start</property>
-            <property name="label" translatable="yes">
-&lt;small&gt; In most configurations, macvtap does not work for
- host to guest network communication.&lt;/small&gt;
-            </property>
+            <property name="label" translatable="yes">&lt;small&gt;In most configurations, macvtap does not work for host to guest network communication.&lt;/small&gt;</property>
             <property name="use-markup">True</property>
             <property name="wrap">True</property>
             <property name="max-width-chars">35</property>
-            <property name="xalign">0</property>
           </object>
           <packing>
             <property name="expand">False</property>
@@ -123,9 +119,7 @@
             <property name="visible">True</property>
             <property name="can-focus">False</property>
             <property name="halign">start</property>
-            <property name="label" translatable="yes">
-              &lt;small&gt;Failed to find a suitable default network.&lt;/small&gt;
-            </property>
+            <property name="label" translatable="yes">&lt;small&gt;Failed to find a suitable default network.&lt;/small&gt;</property>
             <property name="use-markup">True</property>
             <property name="wrap">True</property>
             <property name="max-width-chars">35</property>
@@ -179,11 +173,11 @@
     </child>
     <child>
       <object class="GtkLabel" id="net-macvtap-mode-label">
-        <property name="visible">True</property>
+        <property name="visible">False</property>
         <property name="can-focus">False</property>
         <property name="halign">start</property>
         <property name="hexpand">False</property>
-        <property name="label" translatable="yes">Macvtap _Mode:</property>
+        <property name="label" translatable="yes">Macvtap _mode:</property>
         <property name="use-underline">True</property>
         <property name="mnemonic-widget">net-macvtap-mode</property>
       </object>
@@ -194,10 +188,11 @@
     </child>
     <child>
       <object class="GtkComboBox" id="net-macvtap-mode">
-        <property name="visible">True</property>
+        <property name="visible">False</property>
         <property name="can-focus">False</property>
         <property name="halign">start</property>
-        <property name="hexpand">False</property>
+        <property name="hexpand">True</property>
+        <signal name="changed" handler="on_net_macvtap_mode_changed" swapped="no"/>
       </object>
       <packing>
         <property name="left-attach">1</property>

--- a/ui/netlist.ui
+++ b/ui/netlist.ui
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.38.2 -->
+<!-- Generated with glade 3.40.0 -->
 <interface>
   <requires lib="gtk+" version="3.22"/>
-  <!-- n-columns=2 n-rows=5 -->
+  <!-- n-columns=2 n-rows=6 -->
   <object class="GtkGrid" id="net-source-box">
     <property name="visible">True</property>
     <property name="can-focus">False</property>
@@ -60,10 +60,14 @@
             <property name="visible">True</property>
             <property name="can-focus">False</property>
             <property name="halign">start</property>
-            <property name="label" translatable="yes">&lt;small&gt;In most configurations, macvtap does not work for host to guest network communication.&lt;/small&gt;</property>
+            <property name="label" translatable="yes">
+&lt;small&gt; In most configurations, macvtap does not work for
+ host to guest network communication.&lt;/small&gt;
+            </property>
             <property name="use-markup">True</property>
             <property name="wrap">True</property>
             <property name="max-width-chars">35</property>
+            <property name="xalign">0</property>
           </object>
           <packing>
             <property name="expand">False</property>
@@ -119,7 +123,9 @@
             <property name="visible">True</property>
             <property name="can-focus">False</property>
             <property name="halign">start</property>
-            <property name="label" translatable="yes">&lt;small&gt;Failed to find a suitable default network.&lt;/small&gt;</property>
+            <property name="label" translatable="yes">
+              &lt;small&gt;Failed to find a suitable default network.&lt;/small&gt;
+            </property>
             <property name="use-markup">True</property>
             <property name="wrap">True</property>
             <property name="max-width-chars">35</property>
@@ -169,6 +175,33 @@
       <packing>
         <property name="left-attach">1</property>
         <property name="top-attach">3</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkLabel" id="net-macvtap-mode-label">
+        <property name="visible">True</property>
+        <property name="can-focus">False</property>
+        <property name="halign">start</property>
+        <property name="hexpand">False</property>
+        <property name="label" translatable="yes">Macvtap _Mode:</property>
+        <property name="use-underline">True</property>
+        <property name="mnemonic-widget">net-macvtap-mode</property>
+      </object>
+      <packing>
+        <property name="left-attach">0</property>
+        <property name="top-attach">5</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkComboBox" id="net-macvtap-mode">
+        <property name="visible">True</property>
+        <property name="can-focus">False</property>
+        <property name="halign">start</property>
+        <property name="hexpand">False</property>
+      </object>
+      <packing>
+        <property name="left-attach">1</property>
+        <property name="top-attach">5</property>
       </packing>
     </child>
   </object>

--- a/virtManager/device/netlist.py
+++ b/virtManager/device/netlist.py
@@ -69,12 +69,11 @@ class vmmNetworkList(vmmGObjectUI):
                 "on_net_source_changed": self._on_net_source_changed,
                 "on_net_portgroup_changed": self._emit_changed,
                 "on_net_bridge_name_changed": self._emit_changed,
+                "on_net_macvtap_mode_changed": self._emit_changed,
             }
         )
 
         self._init_ui()
-        # Populate the MACVTAP mode combo box
-        self._populate_macvtap_mode()
         self.top_label = self.widget("net-source-label")
         self.top_box = self.widget("net-source-box")
 
@@ -109,40 +108,15 @@ class vmmNetworkList(vmmGObjectUI):
         combo.set_model(model)
         uiutil.init_combo_text_column(combo, 0)
 
+        combo = self.widget("net-macvtap-mode")
+        model = Gtk.ListStore(str)
+        combo.set_model(model)
+        uiutil.init_combo_text_column(combo, 0)
+        for mode in ["vepa", "bridge", "private", "passthrough"]:
+            model.append([mode])
+
         self.conn.connect("net-added", self._repopulate_network_list)
         self.conn.connect("net-removed", self._repopulate_network_list)
-
-    def _populate_macvtap_mode(self):
-        """
-        Populate the MACVTAP mode ComboBox (net-macvtap-mode)
-        with supported modes and connect its changed signal.
-        """
-        import gi
-        gi.require_version("Gtk", "3.0")
-        from gi.repository import Gtk
-
-        MACVTAP_MODES = ["bridge", "vepa", "private", "passthrough"]
-
-        macvtap_combo = self.widget("net-macvtap-mode")
-        store = Gtk.ListStore(str)
-        macvtap_combo.set_model(store)
-
-        cell = Gtk.CellRendererText()
-        macvtap_combo.pack_start(cell, True)
-        macvtap_combo.add_attribute(cell, "text", 0)
-
-        for mode in MACVTAP_MODES:
-            store.append([mode])
-
-        macvtap_combo.set_active(0)
-        macvtap_combo.connect("changed", self._on_macvtap_mode_changed)
-
-    def _on_macvtap_mode_changed(self, combo):
-        """
-        Called when the MACVTAP mode selection changes.
-        Emits a change signal so that the XML is updated.
-        """
-        self._emit_changed()
 
     def _find_virtual_networks(self):
         rows = []
@@ -205,18 +179,24 @@ class vmmNetworkList(vmmGObjectUI):
         _add_manual_macvtap_row()
         _add_manual_vdpa_row()
 
+        # If there is a bridge device, default to that
         if default_bridge:
             self.widget("net-manual-source").set_text(default_bridge)
             return bridgeidx
 
+        # If not, use 'default' network
         if defaultnetidx is not None:
             return defaultnetidx
 
+        # If not present, use first list entry
         if bridgeidx == 0:
+            # This means we are defaulting to something that
+            # requires manual intervention. Raise the warning
             self.widget("net-default-warn-box").show()
         return 0
 
     def _check_network_is_running(self, net):
+        # Make sure VirtualNetwork is running
         if not net.type == virtinst.DeviceInterface.TYPE_VIRTUAL:
             return
         devname = net.source
@@ -234,21 +214,34 @@ class vmmNetworkList(vmmGObjectUI):
             % devname,
         )
         if not res:
-            return
+            return  # pragma: no cover
 
+        # Try to start the network
         try:
             netobj.start()
             log.debug("Started network '%s'", devname)
-        except Exception as e:
+        except Exception as e:  # pragma: no cover
             return self.err.show_err(
                 _("Could not start virtual network '%(device)s': %(error)s")
-                % {"device": devname, "error": str(e)}
+                % {
+                    "device": devname,
+                    "error": str(e),
+                }
             )
 
     def _find_rowiter_for_dev(self, net):
+        """
+        Find the row in our current model that matches the passed in
+        net device (like populating the details UI for an existing VM).
+        If we don't find a match, we fake it a bit
+        """
         nettype = net.type
         source = net.source
         if net.network:
+            # If using type=network with a forward mode=bridge network,
+            # on domain startup the runtime XML will be changed to
+            # type=bridge and both source/@bridge and source/@network will
+            # be filled in. For our purposes, treat this as a type=network
             source = net.network
             nettype = "network"
 
@@ -262,13 +255,16 @@ class vmmNetworkList(vmmGObjectUI):
                 if _source and rowdata.source != _source:
                     continue
                 if _manual and rowdata.manual != _manual:
-                    continue
+                    continue  # pragma: no cover
                 return row.iter
 
+        # Find the matching row in the net list
         rowiter = _find_row(nettype, source, None)
         if rowiter:
             return rowiter
 
+        # If this is a bridge or macvtap device, show the
+        # manual source mode
         if nettype in [
             virtinst.DeviceInterface.TYPE_BRIDGE,
             virtinst.DeviceInterface.TYPE_DIRECT,
@@ -279,6 +275,8 @@ class vmmNetworkList(vmmGObjectUI):
             if rowiter:
                 return rowiter
 
+        # This is some network type we don't know about. Generate
+        # a label for it and stuff it in the list
         desc = _pretty_network_desc(nettype, source)
         combo.get_model().insert(0, _NetRowData.build_row(nettype, source, desc, True))
         return combo.get_model()[0].iter
@@ -300,14 +298,9 @@ class vmmNetworkList(vmmGObjectUI):
             net_src = self.widget("net-manual-source").get_text() or None
 
         mode = None
-        if net_type == virtinst.DeviceInterface.TYPE_DIRECT:
-            macvtap_combo = self.widget("net-macvtap-mode")
-            store = macvtap_combo.get_model()
-            active_index = macvtap_combo.get_active()
-            if active_index >= 0:
-                mode = store[active_index][0]
-            else:
-                mode = "bridge"
+        is_direct = net_type == virtinst.DeviceInterface.TYPE_DIRECT
+        if is_direct and self.widget("net-macvtap-mode").is_visible():
+            mode = uiutil.get_list_selection(self.widget("net-macvtap-mode"))
 
         portgroup = None
         if self.widget("net-portgroup").is_visible():
@@ -337,13 +330,11 @@ class vmmNetworkList(vmmGObjectUI):
         self.widget("net-default-warn-box").set_visible(False)
         self.widget("net-manual-source").set_text("")
         self.widget("net-portgroup").get_child().set_text("")
+        self.widget("net-macvtap-mode-label").set_visible(False)
+        self.widget("net-macvtap-mode").set_visible(False)
         self._repopulate_network_list()
 
     def set_dev(self, net):
-        """
-        Load an existing device into the UI. If the device is macvtap,
-        read net.source_mode and update the MACVTAP mode combo box accordingly.
-        """
         self.reset_state()
         rowiter = self._find_rowiter_for_dev(net)
 
@@ -353,30 +344,28 @@ class vmmNetworkList(vmmGObjectUI):
 
         if net.portgroup:
             uiutil.set_list_selection(self.widget("net-portgroup"), net.portgroup)
-
-        if net.type == virtinst.DeviceInterface.TYPE_DIRECT:
-            existing_mode = net.source_mode or "bridge"
-            macvtap_combo = self.widget("net-macvtap-mode")
-            store = macvtap_combo.get_model()
-            for idx, row in enumerate(store):
-                if row[0] == existing_mode:
-                    macvtap_combo.set_active(idx)
-                    break
+        if net.source_mode and net.type == virtinst.DeviceInterface.TYPE_DIRECT:
+            uiutil.set_list_selection(self.widget("net-macvtap-mode"), net.source_mode)
 
     #############
     # Listeners #
     #############
 
     def _emit_changed(self, *args, **kwargs):
+        ignore1 = args
+        ignore2 = kwargs
         self.emit("changed")
 
     def _repopulate_network_list(self, *args, **kwargs):
+        ignore1 = args
+        ignore2 = kwargs
+
         netlist = self.widget("net-source")
         current_label = uiutil.get_list_selection(netlist, column=NET_ROW_LABEL)
 
         model = netlist.get_model()
         if not model:
-            return
+            return  # pragma: no cover
 
         try:
             if model:
@@ -410,17 +399,18 @@ class vmmNetworkList(vmmGObjectUI):
         self._emit_changed()
         rowdata = self._get_network_row_data()
         if not rowdata:
-            return
+            return  # pragma: no cover
 
         nettype = rowdata.nettype
         is_direct = nettype == virtinst.DeviceInterface.TYPE_DIRECT
         is_virtual = nettype == virtinst.DeviceInterface.TYPE_VIRTUAL
 
         uiutil.set_grid_row_visible(self.widget("net-macvtap-warn-box"), is_direct)
-        show_bridge = rowdata.manual
-        uiutil.set_grid_row_visible(self.widget("net-manual-source"), show_bridge)
         uiutil.set_grid_row_visible(self.widget("net-macvtap-mode-label"), is_direct)
         uiutil.set_grid_row_visible(self.widget("net-macvtap-mode"), is_direct)
+
+        show_bridge = rowdata.manual
+        uiutil.set_grid_row_visible(self.widget("net-manual-source"), show_bridge)
 
         net = None
         if is_virtual:


### PR DESCRIPTION
MACVTAP has several modes of operation beyond the default of bridge. This change allows the user to specify the mode of operation without having to directly modify the XML in the UI.

This change has been added to allow users in my case to specifically use mode=private. This restricts communication between devices with the same setting (private) but allows for communication with outside systems, even when on the same VLAN. This can be leveraged with external hardware platforms such as firewalls to facilitate micro-segmentation of traffic on the same VLAN.